### PR TITLE
Difficulty selection screen. Line as selector in menus. Text reorder

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -12,8 +12,15 @@ typedef enum {
     RIGHT
 } alignment;
 
+typedef struct {
+    char x;
+    char y;
+    int len;
+} Text_info;
+
+void draw_underline(const Text_info *ti);
 void draw_string(char *str, unsigned int x, unsigned int y);
-void draw_string_align(char *str, unsigned int y, alignment align);
+Text_info draw_string_align_menu(char *str, unsigned int y, alignment align);
 
 void draw_pixel(char x, char y);
 

--- a/include/screens.h
+++ b/include/screens.h
@@ -8,14 +8,7 @@ typedef enum {
     MULTIPLAYER
 } game_mode;
 
-typedef enum {
-    EASY,
-    NORMAL,
-    HARD,
-    IMPOSSIBLE
-} game_difficulty;
-
-void game_screen(game_mode mode, game_difficulty difficulty);
+void game_screen(game_mode mode);
 void high_score_screen();
 
 #endif

--- a/main.c
+++ b/main.c
@@ -48,13 +48,13 @@ selection menu() {
         draw_pixel(0, y_pos);
 
         // up
-        if (btn4_ispressed() && y_pos != 8) {
+        if (btn4_ispressed() && current_selection != SINGLE_PLAYER) {
             y_pos -= 8;
             current_selection--;
         }
 
         // down
-        if (btn3_ispressed() && y_pos != 24) {
+        if (btn3_ispressed() && current_selection != HIGH_SCORE) {
             y_pos += 8;
             current_selection++;
         }
@@ -109,8 +109,8 @@ int main() {
     while (1) {
         selection screen = menu();
 
-        if (screen == SINGLE_PLAYER) game_screen(SINGLE_PLAYER, NORMAL);
-        if (screen == MULTI_PLAYER) game_screen(MULTI_PLAYER, NORMAL); // difficulty doesn't matter here
+        if (screen == SINGLE_PLAYER) game_screen(SINGLE_PLAYER);
+        if (screen == MULTI_PLAYER) game_screen(MULTI_PLAYER);
         if (screen == HIGH_SCORE) high_score_screen();
     }
 

--- a/main.c
+++ b/main.c
@@ -34,28 +34,25 @@ typedef enum {
  */
 selection menu() {
     selection current_selection = SINGLE_PLAYER;
-    int y_pos = 8;
 
     while (1) {
         draw_clear();
 
-        draw_string_align("PONG!", 0, CENTER);
-        draw_string_align("SINGLEPLAYER", 15, LEFT);
-        draw_string_align("MULTIPLAYER", 25, LEFT);
-        draw_string_align("HIGHSCORE", 15, RIGHT);
+        draw_string_align_menu("PONG!", 0, CENTER);
+        Text_info single = draw_string_align_menu("SINGLEPLAYER", 15, LEFT);
+        Text_info multi = draw_string_align_menu("MULTIPLAYER", 15, RIGHT);
+        Text_info high = draw_string_align_menu("HIGHSCORE", 25, CENTER);
 
-        // selection indicator
-        draw_pixel(0, y_pos);
+        Text_info options[] = {single, multi, high};
+        draw_underline(&options[current_selection]);
 
         // up
         if (btn4_ispressed() && current_selection != SINGLE_PLAYER) {
-            y_pos -= 8;
             current_selection--;
         }
 
         // down
         if (btn3_ispressed() && current_selection != HIGH_SCORE) {
-            y_pos += 8;
             current_selection++;
         }
 

--- a/screens/game.c
+++ b/screens/game.c
@@ -13,30 +13,27 @@ typedef enum {
 
 game_difficulty difficulty_selection() {
     game_difficulty current_selection = EASY;
-    int y_pos = 8;
 
     while (1) {
         delay(100); // this causes som issues
         draw_clear();
 
-        draw_string_align("DIFFICULTY!", 0, CENTER);
-        draw_string_align("EASY", 15, LEFT);
-        draw_string_align("NORMAL", 25, LEFT);
-        draw_string_align("HARD", 15, RIGHT);
-        draw_string_align("IMPOSSIBLE", 25, RIGHT);
+        draw_string_align_menu("DIFFICULTY", 0, CENTER);
+        Text_info easy = draw_string_align_menu("EASY", 15, LEFT);
+        Text_info normal = draw_string_align_menu("NORMAL", 25, LEFT);
+        Text_info hard = draw_string_align_menu("HARD", 15, RIGHT);
+        Text_info impossible = draw_string_align_menu("IMPOSSIBLE", 25, RIGHT);
 
-        // selection indicator
-        draw_pixel(0, y_pos);
+        Text_info options[] = {easy, normal, hard, impossible};
+        draw_underline(&options[current_selection]);
 
         // up
         if (btn4_ispressed() && current_selection != EASY) {
-            y_pos -= 8;
             current_selection--;
         }
 
         // down
         if (btn3_ispressed() && current_selection != IMPOSSIBLE) {
-            y_pos += 8;
             current_selection++;
         }
 

--- a/screens/game.c
+++ b/screens/game.c
@@ -2,6 +2,52 @@
 #include "../include/timer.h"
 #include "../include/screens.h"
 #include "../include/buttons.h"
+#include "../include/display.h"
+
+typedef enum {
+    EASY,
+    NORMAL,
+    HARD,
+    IMPOSSIBLE
+} game_difficulty;
+
+game_difficulty difficulty_selection() {
+    game_difficulty current_selection = EASY;
+    int y_pos = 8;
+
+    while (1) {
+        delay(100); // this causes som issues
+        draw_clear();
+
+        draw_string_align("DIFFICULTY!", 0, CENTER);
+        draw_string_align("EASY", 15, LEFT);
+        draw_string_align("NORMAL", 25, LEFT);
+        draw_string_align("HARD", 15, RIGHT);
+        draw_string_align("IMPOSSIBLE", 25, RIGHT);
+
+        // selection indicator
+        draw_pixel(0, y_pos);
+
+        // up
+        if (btn4_ispressed() && current_selection != EASY) {
+            y_pos -= 8;
+            current_selection--;
+        }
+
+        // down
+        if (btn3_ispressed() && current_selection != IMPOSSIBLE) {
+            y_pos += 8;
+            current_selection++;
+        }
+
+        // select
+        if (btn1_ispressed()) {
+            return current_selection;
+        }
+
+        draw_canvas();
+    }
+}
 
 /**
  * Written by: Alex Gunnarsson & Marcus Nilszén
@@ -13,7 +59,13 @@
  * @param difficulty Enum value deciding difficult level
  * in singleplayer vs AI. Has no effect when mode is set to multiplayer.
  */
-void game_screen(game_mode mode, game_difficulty difficulty) {
+void game_screen(game_mode mode) {
+    game_difficulty difficulty;
+
+    if (mode == SINGLEPLAYER) {
+        difficulty = difficulty_selection();
+    }
+
     while (1) {
         draw_clear();
         

--- a/src/display.c
+++ b/src/display.c
@@ -176,8 +176,8 @@ void draw_string(char *str, unsigned int x, unsigned int y) {
 void draw_underline(const Text_info *ti) {
     char x = ti->x;
     char y = ti->y + FONT_SIZE + 1;
-    int i;
-    for (i = x; i < x + ti->len; i++)
+    int i, endX = x + ti->len;
+    for (i = x; i < endX; i++)
         draw_pixel(i, y);
 }
 

--- a/src/display.c
+++ b/src/display.c
@@ -174,6 +174,14 @@ void draw_string(char *str, unsigned int x, unsigned int y) {
     }
 }
 
+void draw_underline(const Text_info *ti) {
+    char x = ti->x;
+    char y = ti->y + 6;
+    int i;
+    for (i = x; i < x + ti->len; i++)
+        draw_pixel(i, y);
+}
+
 /**
  * Written by Marcus Nilszén
  * 
@@ -185,30 +193,33 @@ void draw_string(char *str, unsigned int x, unsigned int y) {
  * @param y Y position.
  * @param align Align text on screen. LEFT, CENTER or RIGHT.
  */
-void draw_string_align(char *str, unsigned int y, alignment align) {
-    if (align == LEFT) {
-        draw_string(str, 0, y);
-        return;
-    }
-
+Text_info draw_string_align_menu(char *str, unsigned int y, alignment align) {
     unsigned int x;
     int len = 0;
     char *str2 = str;
 
     while (*str2) {
-        len += font_width[*str-0x20] + FONT_SPACING;
+        len += font_width[*str2-0x20] + FONT_SPACING;
         str2++;
     }
 
     len -= FONT_SPACING;
 
-    if (align == CENTER) {
+    if (align == LEFT)
+        x = DISPLAY_WIDTH/2 - DISPLAY_WIDTH/4 - len/2;
+    else if (align == RIGHT)
+        x = DISPLAY_WIDTH/2 + DISPLAY_WIDTH/4 - len/2;
+    else
         x = DISPLAY_WIDTH/2 - len/2;
-    } else {
-        x = DISPLAY_WIDTH - len;
-    }
 
     draw_string(str, x, y);
+
+    Text_info ti;
+    ti.x = x;
+    ti.y = y;
+    ti.len = len;
+
+    return ti;
 }
 
 /**

--- a/src/display.c
+++ b/src/display.c
@@ -138,6 +138,7 @@ void display_init() {
 
 /**
  * Written by Marcus Nilszén
+ * Modified by Alex Gunnarsson
  * 
  * @brief Draw a string where the specified cordinate
  * is its upper left corner. Accepts both upper- and

--- a/src/display.c
+++ b/src/display.c
@@ -175,7 +175,7 @@ void draw_string(char *str, unsigned int x, unsigned int y) {
 
 void draw_underline(const Text_info *ti) {
     char x = ti->x;
-    char y = ti->y + 6;
+    char y = ti->y + FONT_SIZE + 1;
     int i;
     for (i = x; i < x + ti->len; i++)
         draw_pixel(i, y);

--- a/src/display.c
+++ b/src/display.c
@@ -137,8 +137,7 @@ void display_init() {
 }
 
 /**
- * Written by Marcus Nilszén
- * Modified by Alex Gunnarsson
+ * Written by Marcus Nilszén & Alex Gunnarsson
  * 
  * @brief Draw a string where the specified cordinate
  * is its upper left corner. Accepts both upper- and


### PR DESCRIPTION
One way to solve underlining.

Main menu:
<img width="302" alt="image" src="https://user-images.githubusercontent.com/39590503/143084684-302bfd49-d819-4d04-b666-f62ab3a4ff89.png">

Difficulty selection screen:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/39590503/143084729-de090d00-0d3d-4bcc-8476-0bd5a5843dde.png">

